### PR TITLE
Consistently use macros for model definitions

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -26,16 +26,16 @@ clean-targets: # Directories to be removed by `dbt clean`.
 vars:
   snowplow_recommendations:
     # Add all tables that you want to export to S3 (and then to AWS Personalize).
-    tables_to_export: [ 
+    tables_to_export: [
       "snowplow_recommendations_ecommerce_interactions",
       "snowplow_recommendations_ecommerce_items",
       "snowplow_recommendations_ecommerce_users",
       "snowplow_recommendations_media_interactions"
-    ] 
+    ]
 
     # Snowflake variables
     snowflake_stage_name: "PersonalizeS3Stage"
-    
+
     # Databricks variables
     external_catalog: 'aws_personalize' # The name of the external Databricks catalog, can be found in the Terraform files/output.
     s3_bucket: 's3://' # Requires the full s3 bucket path i.e. s3://<bucket_name>
@@ -44,27 +44,23 @@ vars:
   # snowplow__license_accepted: false # Set to true to accept the license.
 
   # Below are only for ecommerce
-  ecommerce_product_schema: '' # Only set if not using 'derived' schema for Snowplow ecommerce events data.
-  # ecommerce_product_database: '' # Only set if not using target database for Snowplow ecommerce events data.
-  ecommerce_product_source: "{{ ref('snowplow_ecommerce', 'snowplow_ecommerce_product_interactions') }}" # override with your ecommerce product interations table.
+  ecommerce_product_source: "{{ ref('snowplow_ecommerce', 'snowplow_ecommerce_product_interactions') }}" # override with your e-commerce product interactions table.
   ecommerce_start_date: '2025-01-01'
   ecommerce_end_date: '2025-01-31'
   ecommerce_look_back_days: 31
   ecommerce_product_categories_separator: '/'
-  
-  # Below are only for media (video_on_demand) 
+
+  # Below are only for media (video_on_demand)
   # snowplow__enable_youtube: true # Set to true if the YouTube context schema is enabled.
   # snowplow__enable_whatwg_media: true # Set to true if the HTML5 media element context schema is enabled.
-  media_product_schema: '' # Only set if not using 'derived' schema for Snowplow media events data.
-  media_product_database: '' # Only set if not using target database schema for Snowplow media events data.
-  media_player_source: "{{ ref('snowplow_media_player', 'snowplow_media_player_base') }}"
+  media_player_source: "{{ ref('snowplow_media_player', 'snowplow_media_player_base') }}" # override with your media product interactions table.
   media_start_date: '2025-01-01'
   media_end_date: '2025-01-31'
   media_look_back_days: 31
 
 on-run-end:
   - "{{ export_to_s3() }}"
-  
+
 models:
   snowplow_recommendations:
     +materialized: table

--- a/docs/snowplow_recommendations_macros_docs.md
+++ b/docs/snowplow_recommendations_macros_docs.md
@@ -1,5 +1,14 @@
+{% docs macro_create_ecommerce_interactions %}
+This macro is used to build the sql query to create the model for the E-commerce Interactions dataset.
+To allow for the customization of each user's different metadata they'd like to have in this dataset/model we recommend writing
+your dataset model in this macro.
+
+#### Returns
+
+The sql to create the model for E-commerce's Interactions dataset.
+{% enddocs %}
+
 {% docs macro_create_ecommerce_items %}
-{% raw %}		
 This macro is used to build the sql query to create the model for the E-commerce Items dataset.
 To allow for the customization of each user's different metadata they'd like to have in this dataset/model we recommend writing
 your dataset model in this macro.
@@ -7,11 +16,9 @@ your dataset model in this macro.
 #### Returns
 
 The sql to create the model for E-commerce's Items dataset.
-{% endraw %}
 {% enddocs %}
 
 {% docs macro_create_ecommerce_users %}
-{% raw %}		
 This macro is used to build the sql query to create the model for the E-commerce Users dataset.
 To allow for the customization of each user's different metadata they'd like to have in this dataset/model we recommend writing
 your dataset model in this macro.
@@ -19,18 +26,26 @@ your dataset model in this macro.
 #### Returns
 
 The sql to create the model for E-commerce's Users dataset.
-{% endraw %}
+{% enddocs %}
+
+{% docs macro_create_media_interactions %}
+This macro is used to build the sql query to create the model for the Media Interactions dataset.
+To allow for the customization of each user's different metadata they'd like to have in this dataset/model we recommend writing
+your dataset model in this macro.
+
+#### Returns
+
+The sql to create the model for Media's Interactions dataset.
 {% enddocs %}
 
 {% docs macro_export_data_to_s3 %}
-{% raw %}		
-This macro is used to export the tables listed in the var `tables_to_export` when the dbt package is running on a Snowflake warehouse.
-{% endraw %}
+This macro is used to export the tables listed in the var `tables_to_export` after the dbt package finishes running.
+This macro dispatches to adapter implementations, only a Snowflake implementation is provided.
+The Snowflake implementation depends on the `snowflake_stage_name` var.
 {% enddocs %}
 
 {% docs macro_external_table_config %}
-{% raw %}		
-When the target warehouse is Databricks then this macro will dump the required configurations to your model(s) to allow them to be
-created as external tables on AWS S3. The tables will then be unloaded as csv files to the S3 bucket configured via the var `s3_bucket`.
-{% endraw %}
+This macro checks the current model against the `tables_to_export` var, and if it matches, updates the current model's config to export to the external catalog in the `external_catalog` var.
+This is only implemented if the target warehouse is Databricks, and creates external tables on AWS S3.
+The tables will then be unloaded as csv files to the S3 bucket configured via the var `s3_bucket`.
 {% enddocs %}

--- a/macros/create_ecommerce_interactions.sql
+++ b/macros/create_ecommerce_interactions.sql
@@ -1,0 +1,39 @@
+{#
+Copyright (c) 2023-present Snowplow Analytics Ltd. All rights reserved.
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
+#}
+
+{% macro create_ecommerce_interactions() %}
+  {{ return(adapter.dispatch('create_ecommerce_interactions', 'snowplow_recommendations')()) }}
+{% endmacro %}
+
+{% macro default__create_ecommerce_interactions() %}
+  {% if target.type in ('snowflake', 'databricks') %}
+    select
+      coalesce(ecommerce_user_id, domain_userid) as user_id,
+      product_id as item_id,
+      {{ snowplow_utils.to_unixtstamp("derived_tstamp") }} as timestamp,
+
+      case
+        when is_product_view then 'View' else 'Purchase'
+      end as event_type
+
+    from {{ var('ecommerce_product_source' ) }}
+      where (is_product_view or is_product_transaction)
+
+      and (date(derived_tstamp) >= {%- if var('ecommerce_start_date') == '' %}
+                                    current_date() - '{{ var('ecommerce_look_back_days') }}'
+                                    {%- else %}
+                                    '{{ var('ecommerce_start_date') }}'
+                                    {%- endif %}
+        and date(derived_tstamp) <= {%- if var('ecommerce_end_date') == '' %}
+                                    current_date() - 1
+                                    {%- else %}
+                                    '{{ var('ecommerce_end_date') }}'
+                                    {%- endif %})
+  {% else %}
+    {% do exceptions.raise_compiler_error('Macro create_ecommerce_interactions is only for Snowflake or Databricks, it is not supported for ' ~ target.type) %}
+  {% endif %}
+{% endmacro %}

--- a/macros/create_media_interactions.sql
+++ b/macros/create_media_interactions.sql
@@ -1,0 +1,36 @@
+{#
+Copyright (c) 2023-present Snowplow Analytics Ltd. All rights reserved.
+This program is licensed to you under the Snowplow Personal and Academic License Version 1.0,
+and you may not use this file except in compliance with the Snowplow Personal and Academic License Version 1.0.
+You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 at https://docs.snowplow.io/personal-and-academic-license-1.0/
+#}
+
+{% macro create_media_interactions() %}
+  {{ return(adapter.dispatch('create_media_interactions', 'snowplow_recommendations')()) }}
+{% endmacro %}
+
+{% macro default__create_media_interactions() %}
+  {% if target.type in ('snowflake', 'databricks') %}
+    select
+      coalesce(cast(user_id as string), user_identifier) as user_id,
+      media_identifier as item_id,
+      {{ snowplow_utils.to_unixtstamp("start_tstamp") }} as timestamp,
+      'Watch' as event_type
+
+    from {{ var("media_player_source") }} as e
+
+      where (date(start_tstamp) >= {%- if var('media_start_date') == '' %}
+                                    current_date() - '{{ var('media_look_back_days') }}'
+                                    {%- else %}
+                                    '{{ var('media_start_date') }}'
+                                    {%- endif %}
+        and date(start_tstamp) <= {%- if var('media_end_date') == '' %}
+                                    current_date() - 1
+                                    {%- else %}
+                                    '{{ var('media_end_date') }}'
+                                    {%- endif %})
+        and is_valid_play = True
+  {% else %}
+    {% do exceptions.raise_compiler_error('Macro create_media_interactions is only for Snowflake or Databricks, it is not supported for ' ~ target.type) %}
+  {% endif %}
+{% endmacro %}

--- a/macros/macros.yml
+++ b/macros/macros.yml
@@ -1,10 +1,14 @@
 version: 2
 
 macros:
+  - name: create_ecommerce_interactions
+    description: '{{ doc("macro_create_ecommerce_interactions") }}'
   - name: create_ecommerce_items
     description: '{{ doc("macro_create_ecommerce_items") }}'
   - name: create_ecommerce_users
     description: '{{ doc("macro_create_ecommerce_users") }}'
+  - name: create_media_interactions
+    description: '{{ doc("macro_create_media_interactions") }}'
   - name: export_data_to_s3
     description: '{{ doc("macro_export_data_to_s3") }}'
   - name: external_table_config

--- a/models/ecommerce/snowplow_recommendations_ecommerce_interactions.sql
+++ b/models/ecommerce/snowplow_recommendations_ecommerce_interactions.sql
@@ -15,25 +15,4 @@ You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 
 {{ external_table_config(this.name) }}
 
 
-select
-  coalesce(ecommerce_user_id, domain_userid) as user_id,
-  product_id as item_id,
-  {{ snowplow_utils.to_unixtstamp("derived_tstamp") }} as timestamp,
- 
-  case
-    when is_product_view then 'View' else 'Purchase'
-  end as event_type
-
-from {{ var('ecommerce_product_source' ) }}
-  where (is_product_view or is_product_transaction)
-
-  and (date(derived_tstamp) >= {%- if var('ecommerce_start_date') == '' %}
-                                 current_date() - '{{ var('ecommerce_look_back_days') }}'
-                                {%- else %}
-                                '{{ var('ecommerce_start_date') }}'
-                                {%- endif %}
-    and date(derived_tstamp) <= {%- if var('ecommerce_end_date') == '' %}
-                                 current_date() - 1
-                                {%- else %}
-                                '{{ var('ecommerce_end_date') }}'
-                                {%- endif %})
+{{ create_ecommerce_interactions() }}

--- a/models/media/snowplow_recommendations_media_interactions.sql
+++ b/models/media/snowplow_recommendations_media_interactions.sql
@@ -15,23 +15,4 @@ You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 
 {{ external_table_config(this.name) }}
 
 
-
-select
-  coalesce(cast(user_id as string), user_identifier) as user_id,
-  media_identifier as item_id,
-  {{ snowplow_utils.to_unixtstamp("start_tstamp") }} as timestamp,
-  'Watch' as event_type
-
-from {{ var("media_player_source") }} as e
-
-  where (date(start_tstamp) >= {%- if var('media_start_date') == '' %}
-                                 current_date() - '{{ var('media_look_back_days') }}'
-                                {%- else %}
-                                '{{ var('media_start_date') }}'
-                                {%- endif %}
-    and date(start_tstamp) <= {%- if var('media_end_date') == '' %}
-                                 current_date() - 1
-                                {%- else %}
-                                '{{ var('media_end_date') }}'
-                                {%- endif %})
-    and is_valid_play = True
+{{ create_media_interactions() }}

--- a/models/schema.yml
+++ b/models/schema.yml
@@ -24,7 +24,25 @@ models:
         description: "Derived timestamp of the event in epoch seconds."
       - name: event_type
         description: "Both `page_view` and `list_view` ecommerce event types and `transaction` events."
-  
+
+  - name: snowplow_recommendations_ecommerce_items
+    description: "Training dataset for AWS Personalize's ecommerce recommendations."
+    columns:
+      - name: item_id
+        description: "The product ID."
+      - name: price
+        description: "The price of the product."
+      - name: category_l1
+        description: "The primary category the product belongs to."
+
+  - name: snowplow_recommendations_ecommerce_users
+    description: "Training dataset for AWS Personalize's ecommerce recommendations."
+    columns:
+      - name: user_id
+        description: "Snowplow Ecommerce user ID."
+      - name: user_is_guest
+        description: "Whether the user is a guest or not; a guest is a user without an associated user_id/account, meaning their user_id here is the domain_userid."
+
   - name: snowplow_recommendations_media_interactions
     description: "Training dataset for AWS Personalize's media recommendations."
     columns:

--- a/models/schema.yml
+++ b/models/schema.yml
@@ -1,17 +1,5 @@
 version: 2
 
-sources:
-  - name: ecommerce
-    schema: "{{ var('ecommerce_product_schema', 'derived') }}"
-    database: "{{ var('ecommerce_product_database', target.database) }}"
-    tables:
-      - name: snowplow_ecommerce_product_interactions
-  - name: media
-    schema: "{{ var('media_product_schema', 'derived') }}"
-    database: "{{ var('media_product_database', target.database) }}"
-    tables:
-      - name: snowplow_media_player_base
-
 models:
   - name: snowplow_recommendations_ecommerce_interactions
     description: "Training dataset for AWS Personalize's ecommerce recommendations."


### PR DESCRIPTION
This makes the model definitions all use the same pattern for consistency.
It looks like historically, two people implemented the models, one used this approach, the other just defined the models with the queries inline. I thought it was me but it wasn't, but here's a fix anyway. :sweat_smile: 
I don't really have an opinion which approach is better, but they should be consistent, so I went with the older pattern here, even though it's slightly more complicated.

It also removes the now unused `source` definitions and the `var`s that were used to configure them, fixing #2.